### PR TITLE
Updated Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ A terminal interface for Slack.
 ##Controls
  - Ctrl-c - select channels list
     - Use the arrow keys and enter to select a channel
- - Ctrl-r - select direct message list
+ - Ctrl-u - select direct message list
     - Use the arrow keys and enter to select a channel (unfinished)
  - Ctrl-w - select writing area
     - Use enter to send a message


### PR DESCRIPTION
Fixed a typo, the code shows C-u for accessing the direct user message list, but the doc was showing Ctrl+r.